### PR TITLE
NTR - Add update parameters to unapprove changes from core in crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,6 +7,7 @@ files: [{
     "source": "/en-GB/**/*.json",
     "translation": "/%locale%/**/%original_file_name%",
     "type": "json",
+    "update_option": "update_as_unapproved",
     "translation_replace": {
         "no-NO": "nn-NO"
     },
@@ -18,10 +19,11 @@ files: [{
 }, {
     "source": "/en-GB/**/*.json",
     "translation": "/%two_letters_code%/**/%original_file_name%",
+    "type": "json",
+    "update_option": "update_as_unapproved",
     "translation_replace": {
         "de": "de-DE"
     },
-    "type": "json",
     "languages_mapping": {
         "two_letters_code": {
             "ar": "ar-SA",


### PR DESCRIPTION
We currently have the state, where changes in the core are just added into crowdin, without being accepted and therefore changes there have to be done in crowdin as well.

This change removes approvals of changed snippets so they can at least easily be checked again