### PR TITLE
ci: use octo-sts token to push

### DIFF
--- a/.github/chainguard/TranslationsUpdatePush.sts.yaml
+++ b/.github/chainguard/TranslationsUpdatePush.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:shopware/translations:.*
+claim_pattern:
+  workflow_ref: shopware/translations/.github/workflows/update-translations.yml@refs/heads/main
+
+permissions:
+  contents: write

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -28,6 +28,11 @@ jobs:
         with:
           scope: shopware
           identity: TranslationsUpdate
+      - uses: octo-sts/action@v1.0.0
+        id: octo-sts-push
+        with:
+          scope: shopware/translations
+          identity: TranslationsUpdatePush
       - name: Update platform
         run: |
           for lang in en-GB de-DE; do
@@ -114,6 +119,6 @@ jobs:
               git commit -m "$(date -I) - Update translations"
               # Reset auth back to GITHUB_TOKEN
               git config --unset http."https://github.com/".extraheader || true
-              git config --global "http.https://github.com/".extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${{ secrets.GITHUB_TOKEN }}" | base64)"
+              git config --global "http.https://github.com/".extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${{ steps.octo-sts-push.outputs.token }}" | base64)"
               git push origin main
           fi


### PR DESCRIPTION
Github doesn't allow to set the `GITHUB_TOKEN` to bypass the branch protection. So we need to use a octo-sts token to push the changes, as Apps could be set as bypasser.